### PR TITLE
use document-edit-symbolic

### DIFF
--- a/usr/share/webapp-manager/webapp-manager.ui
+++ b/usr/share/webapp-manager/webapp-manager.ui
@@ -146,7 +146,7 @@
                               <object class="GtkImage">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="icon_name">list-edit-symbolic</property>
+                                <property name="icon_name">document-edit-symbolic</property>
                               </object>
                             </child>
                           </object>


### PR DESCRIPTION
use document-edit-symbolic instead of list-edit-symbolic as it does not exist on at least on Ubuntu 20.04.1