### PR TITLE
[Feature] Confirmation dialog before deletion

### DIFF
--- a/usr/lib/webapp-manager/webapp-manager.py
+++ b/usr/lib/webapp-manager/webapp-manager.py
@@ -274,7 +274,35 @@ class WebAppManagerWindow():
 
     def on_remove_button(self, widget):
         if self.selected_webapp != None:
-            self.manager.delete_webbapp(self.selected_webapp)
+            confrmdlg = Gtk.MessageDialog(message_type=Gtk.MessageType.WARNING)
+            confrmdlg.set_transient_for(self.window)
+            confrmdlg.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_DELETE, Gtk.ResponseType.YES)
+            
+            # icon = GdkPixbuf.Pixbuf.new_from_file(self.selected_webapp.icon)
+            if "/" in self.selected_webapp.icon and os.path.exists(self.selected_webapp.icon):
+                    icon = GdkPixbuf.Pixbuf.new_from_file_at_size(self.selected_webapp.icon, -1, 32 * self.window.get_scale_factor())
+            else:
+                if self.icon_theme.has_icon(self.selected_webapp.icon):
+                    icon = self.icon_theme.load_icon(self.selected_webapp.icon, 32 * self.window.get_scale_factor(), 0)
+                else:
+                    icon = self.icon_theme.load_icon("webapp-manager", 32 * self.window.get_scale_factor(), 0)
+            confrmdlg.set_icon(icon)
+            
+            title_txt=_("Delete "+self.selected_webapp.name)
+            confrmdlg.set_title(title_txt)
+            
+            # Warning message
+            confrmtext = _("Are you sure you want to delete webapp \"" + self.selected_webapp.name + "\"?")
+            confrmdlg.set_property("text", confrmtext)
+            confrmdlg.format_secondary_text(_("If you delete this webapp, it will be permanently lost."))
+            
+            # run confrimation dialog
+            confrmdlg.show()
+            response = confrmdlg.run()
+            if response == Gtk.ResponseType.YES:
+                self.manager.delete_webbapp(self.selected_webapp)
+            
+            confrmdlg.destroy()
             self.load_webapps()
 
     def run_webapp(self, webapp):


### PR DESCRIPTION
This PR fixes and closes the following issues:

1. Feature Request: Confirm on Delete #66
2. Add a Confirm dialogue before app removal #75

Tested on:

1. Ubuntu Mate 20.04.2
2. Ubuntu 20.10
3. Ubuntu 21.04

closes #66, closes #75


![ezgif-6-fa8ee4357381](https://user-images.githubusercontent.com/41947504/134170881-0c71c7ff-070d-4320-abd4-b31625e6202a.gif)
 