### PR TITLE
Fix for epiphany; fixes #104

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -149,10 +149,14 @@ class WebAppManager():
 
     def delete_webbapp(self, webapp):
         shutil.rmtree(os.path.join(FIREFOX_PROFILES_DIR, webapp.codename), ignore_errors=True)
-        shutil.rmtree(os.path.join(EPIPHANY_PROFILES_DIR, "/epiphany-%s" % webapp.codename), ignore_errors=True)
         shutil.rmtree(os.path.join(PROFILES_DIR, webapp.codename), ignore_errors=True)
+        # first remove symlinks then others
         if os.path.exists(webapp.path):
             os.remove(webapp.path)
+        epiphany_orig_prof_dir=os.path.join(os.path.expanduser("~/.local/share"), "org.gnome.Epiphany.WebApp-" + webapp.codename)
+        if os.path.exists(epiphany_orig_prof_dir):
+            os.remove(epiphany_orig_prof_dir)
+        shutil.rmtree(os.path.join(EPIPHANY_PROFILES_DIR, "org.gnome.Epiphany.WebApp-%s" % webapp.codename), ignore_errors=True)
 
     def create_webapp(self, name, url, icon, category, browser, isolate_profile=True, navbar=False, privatewindow=False):
         # Generate a 4 digit random code (to prevent name collisions, so we can define multiple launchers with the same name)
@@ -183,10 +187,13 @@ class WebAppManager():
                     shutil.copy('/usr/share/webapp-manager/firefox/userChrome-with-navbar.css', os.path.join(firefox_profile_path, "chrome", "userChrome.css"))
             elif browser.browser_type == BROWSER_TYPE_EPIPHANY:
                 # Epiphany based
-                epiphany_profile_path = os.path.join(EPIPHANY_PROFILES_DIR, "epiphany-" + codename)
+                epiphany_profile_path = os.path.join(EPIPHANY_PROFILES_DIR, "org.gnome.Epiphany.WebApp-" + codename)
+                # Create symlink of profile dir at ~/.local/share
+                epiphany_orig_prof_dir=os.path.join(os.path.expanduser("~/.local/share"), "org.gnome.Epiphany.WebApp-" + codename)
+                os.symlink(epiphany_profile_path, epiphany_orig_prof_dir)
                 desktop_file.write("Exec=" + browser.exec_path +
                                     " --application-mode " +
-                                    " --profile=\"" + epiphany_profile_path + "\"" +
+                                    " --profile=\"" + epiphany_orig_prof_dir + "\"" +
                                     " " + url + "\n")
             else:
                 # Chromium based
@@ -225,10 +232,17 @@ class WebAppManager():
 
             if browser.browser_type == BROWSER_TYPE_EPIPHANY:
                 # Move the desktop file and create a symlink
-                new_path = os.path.join(epiphany_profile_path, "epiphany-%s.desktop" % codename)
+                new_path = os.path.join(epiphany_profile_path, "org.gnome.Epiphany.WebApp-%s.desktop" % codename)
                 os.makedirs(epiphany_profile_path)
                 os.replace(path, new_path)
                 os.symlink(new_path, path)
+                # copy the icon to profile directory
+                new_icon=os.path.join(epiphany_profile_path, "app-icon.png")
+                shutil.copy(icon, new_icon)
+                # required for app mode. create an empty file .app
+                app_mode_file=os.path.join(epiphany_profile_path, ".app")
+                with open(app_mode_file, 'w') as fp:
+                    pass
 
     def edit_webapp(self, path, name, url, icon, category):
         config = configparser.RawConfigParser()


### PR DESCRIPTION
This fix contains the errors related to launching in
Epiphany aka GNOME Web.

Epiphany follows very strict method implementing app-mode.
The profile directory should be in `~/.local/share`,
profile name should start with `org.gnome.Epiphany.WebApp-` and
the icon should be located in the profile directory with name `app-icon.png`

Known issues/bugs:
1. when a web-app is created with icons from system theme, the web-app will fail to launch because the icon is not copied to profile directory.

EDIT:
This PR is probably irrelevant because Epiphany from apt repo in Ubuntu 20.04 uses prefix `epiphany-` while Epiphany in Ubuntu 21.04 uses `org.gnome.Epiphany.WebApp-`. So I shall leave the decision to LM maintainers whether to keep this PR or not.