### PR TITLE
Improve cookie management in Firefox & Librewolf

### DIFF
--- a/usr/share/webapp-manager/firefox/profile/user.js
+++ b/usr/share/webapp-manager/firefox/profile/user.js
@@ -8,6 +8,5 @@ user_pref("browser.ctrlTab.previews", true);
 user_pref("browser.tabs.warnOnClose", false);
 user_pref("plugin.state.flash", 2);
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
-user_pref("privacy.firstparty.isolate", true);
-user_pref("network.cookie.cookieBehavior", 1);
+user_pref("browser.contentblocking.category", "strict");
 user_pref("network.cookie.lifetimePolicy", 0);

--- a/usr/share/webapp-manager/firefox/profile/user.js
+++ b/usr/share/webapp-manager/firefox/profile/user.js
@@ -8,3 +8,6 @@ user_pref("browser.ctrlTab.previews", true);
 user_pref("browser.tabs.warnOnClose", false);
 user_pref("plugin.state.flash", 2);
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
+user_pref("privacy.firstparty.isolate", true);
+user_pref("network.cookie.cookieBehavior", 1);
+user_pref("network.cookie.lifetimePolicy", 0);


### PR DESCRIPTION
Enable cookie isolation for enhanced privacy. Facilitate #149 by enabling cookies in Librewolf (and any other browsers that clears cookies by default).