### PR TITLE
Implemented custom browser parameters

### DIFF
--- a/usr/lib/webapp-manager/webapp-manager.py
+++ b/usr/lib/webapp-manager/webapp-manager.py
@@ -85,6 +85,7 @@ class WebAppManagerWindow():
         self.name_entry = self.builder.get_object("name_entry")
         self.url_entry = self.builder.get_object("url_entry")
         self.url_label = self.builder.get_object("url_label")
+        self.customparameters_entry = self.builder.get_object("customparameters_entry")
         self.isolated_switch = self.builder.get_object("isolated_switch")
         self.isolated_label = self.builder.get_object("isolated_label")
         self.navbar_switch = self.builder.get_object("navbar_switch")
@@ -311,6 +312,7 @@ class WebAppManagerWindow():
         navbar = self.navbar_switch.get_active()
         privatewindow = self.privatewindow_switch.get_active()
         icon = self.icon_chooser.get_icon()
+        custom_parameters = self.customparameters_entry.get_text()
         if "/tmp" in icon:
             # If the icon path is in /tmp, move it.
             filename = "".join(filter(str.isalpha, name)) + ".png"
@@ -318,15 +320,16 @@ class WebAppManagerWindow():
             shutil.copyfile(icon, new_path)
             icon = new_path
         if self.edit_mode:
-            self.manager.edit_webapp(self.selected_webapp.path, name, browser, url, icon, category)
+            self.manager.edit_webapp(self.selected_webapp.path, name, browser, url, icon, category, custom_parameters)
             self.load_webapps()
         else:
-            self.manager.create_webapp(name, url, icon, category, browser, isolate_profile, navbar, privatewindow)
+            self.manager.create_webapp(name, url, icon, category, browser, custom_parameters, isolate_profile, navbar, privatewindow)
             self.load_webapps()
 
     def on_add_button(self, widget):
         self.name_entry.set_text("")
         self.url_entry.set_text("")
+        self.customparameters_entry.set_text("")
         self.icon_chooser.set_icon("webapp-manager")
         self.category_combo.set_active(0)
         self.browser_combo.set_active(0)
@@ -347,6 +350,7 @@ class WebAppManagerWindow():
             self.name_entry.set_text(self.selected_webapp.name)
             self.icon_chooser.set_icon(self.selected_webapp.icon)
             self.url_entry.set_text(self.selected_webapp.url)
+            self.customparameters_entry.set_text(self.selected_webapp.custom_parameters)
             model = self.category_combo.get_model()
             iter = model.get_iter_first()
             while iter:

--- a/usr/share/webapp-manager/webapp-manager.ui
+++ b/usr/share/webapp-manager/webapp-manager.ui
@@ -311,7 +311,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="top_attach">9</property>
                     <property name="width">3</property>
                   </packing>
                 </child>
@@ -421,7 +421,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">5</property>
+                    <property name="top_attach">6</property>
                   </packing>
                 </child>
                 <child>
@@ -433,7 +433,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">5</property>
+                    <property name="top_attach">6</property>
                   </packing>
                 </child>
                 <child>
@@ -444,7 +444,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">6</property>
+                    <property name="top_attach">7</property>
                   </packing>
                 </child>
                 <child>
@@ -458,7 +458,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">6</property>
+                    <property name="top_attach">7</property>
                   </packing>
                 </child>
                 <child>
@@ -469,7 +469,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">7</property>
+                    <property name="top_attach">8</property>
                   </packing>
                 </child>
                 <child>
@@ -483,8 +483,35 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
+                    <property name="top_attach">8</property>
                   </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="customparameters_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Custom parameters:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="customparameters_entry">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="width_chars">40</property>
+                    <property name="placeholder_text" translatable="yes">Custom browser parameters</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
                 <child>
                   <placeholder/>


### PR DESCRIPTION
This PR adds support for custom parameters. This allows parameters to be added to the browser executable without editing the .desktop file, which will still be overwritten when editing an entry in the web application manager.

![Снимок экрана_2022-06-05_23-29-34](https://user-images.githubusercontent.com/3750982/172071740-1da8521b-f781-4bf2-9030-401f5898941f.png)

