### PR TITLE
Reorder Imports

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -1,15 +1,29 @@
 #!/usr/bin/python3
+
+#   1. Standard library imports.
 import configparser
 import gettext
-import gi
+from io import BytesIO
+import json
 import locale
 import os
+from random import choice
 import shutil
 import string
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
 import threading
 import traceback
+
+#   2. Related third party imports.
 from gi.repository import GObject
-from random import choice
+from PIL import Image
+import requests
+# Note: BeautifulSoup is an optional import supporting another way of getting a website's favicons.
+
 
 # Used as a decorator to run things in the background
 def _async(func):
@@ -282,14 +296,6 @@ class WebAppManager():
         with open(path, 'w') as configfile:
             config.write(configfile, space_around_delimiters=False)
 
-import sys
-import urllib.error
-import urllib.parse
-import urllib.request
-from PIL import Image
-from io import BytesIO
-import requests
-import json
 
 def normalize_url(url):
     (scheme, netloc, path, _, _, _) = urllib.parse.urlparse(url, "http")
@@ -314,8 +320,6 @@ def download_image(root_url, link):
         print(link)
         image = None
     return image
-
-import tempfile
 
 def _find_link_favicon(soup, iconformat):
     items = soup.find_all("link", {"rel": iconformat})

--- a/usr/lib/webapp-manager/webapp-manager.py
+++ b/usr/lib/webapp-manager/webapp-manager.py
@@ -1,14 +1,17 @@
 #!/usr/bin/python3
+
+#   1. Standard library imports.
 import gettext
-import gi
 import locale
 import os
-import re
-import setproctitle
 import shutil
 import subprocess
-import tldextract
 import warnings
+
+#   2. Related third party imports.
+import gi
+import setproctitle
+import tldextract
 
 # Suppress GTK deprecation warnings
 warnings.filterwarnings("ignore")
@@ -17,6 +20,7 @@ gi.require_version("Gtk", "3.0")
 gi.require_version('XApp', '1.0')
 from gi.repository import Gtk, Gdk, Gio, XApp, GdkPixbuf, GLib
 
+#   3. Local application/library specific imports.
 from common import _async, idle, WebAppManager, Browser, download_favicon, ICONS_DIR, BROWSER_TYPE_FIREFOX
 
 setproctitle.setproctitle("webapp-manager")


### PR DESCRIPTION
This PR is janitorial in nature and adds no new functionality.

Here are the changes:
* Removes unused import `re`
* Moves imports to top of the file.
* Reorganizes the imports to PEP8 order.

The last two are per [PEP8 on Imports](https://peps.python.org/pep-0008/#imports).