### PR TITLE
Update common.py to add --name parameter to .desktop Exec=  Firefox and Librewolf 

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -213,6 +213,7 @@ class WebAppManager():
                 firefox_profile_path = os.path.join(firefox_profiles_dir, codename)
                 exec_string = ("Exec=sh -c 'XAPP_FORCE_GTKWINDOW_ICON=" + icon + " " + browser.exec_path +
                                     " --class WebApp-" + codename +
+                                    " --name WebApp-" + codename +
                                     " --profile " + firefox_profile_path +
                                     " --no-remote ")
                 if privatewindow:
@@ -230,6 +231,7 @@ class WebAppManager():
                 firefox_profile_path = os.path.join(firefox_profiles_dir, codename)
                 exec_string = ("Exec=sh -c 'XAPP_FORCE_GTKWINDOW_ICON=" + icon + " " + browser.exec_path +
                                     " --class WebApp-" + codename +
+                                    " --name WebApp-" + codename + 
                                     " --profile " + firefox_profile_path +
                                     " --no-remote ")
                 if privatewindow:


### PR DESCRIPTION
Add --name (classname) to the .desktop files allows each webapp to have a separate instance  on the taskbar.