### PR TITLE
Add Brave (flatpak) as target browser

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -184,6 +184,7 @@ class WebAppManager():
         browsers.append(Browser(BROWSER_TYPE_CHROMIUM, "Chromium (Flatpak)", "/var/lib/flatpak/exports/bin/org.chromium.Chromium", "/var/lib/flatpak/exports/bin/org.chromium.Chromium"))
         browsers.append(Browser(BROWSER_TYPE_FALKON, "Falkon", "falkon", "/usr/bin/falkon"))
         browsers.append(Browser(BROWSER_TYPE_CHROMIUM, "Edge (Flatpak)", "/var/lib/flatpak/exports/bin/com.microsoft.Edge", "/var/lib/flatpak/exports/bin/com.microsoft.Edge"))
+        browsers.append(Browser(BROWSER_TYPE_CHROMIUM, "Brave (Flatpak)", "/var/lib/flatpak/exports/bin/com.brave.Browser", "/var/lib/flatpak/exports/bin/com.brave.Browser"))
         return browsers
 
     def delete_webbapp(self, webapp):


### PR DESCRIPTION
Add the ability to use flatpak-ed variant of Brave as a target browser for Webapps.

Relates to https://www.reddit.com/r/linuxmint/comments/xgb4t4/webapp_manager_grayed_out_options/

May also relate to #192