### PR TITLE
common.py Fix icons for firefox .desktop files

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -284,6 +284,7 @@ class WebAppManager:
             firefox_profile_path = os.path.join(firefox_profiles_dir, codename)
             exec_string = ("sh -c 'XAPP_FORCE_GTKWINDOW_ICON=\"" + icon + "\" " + browser.exec_path +
                            " --class WebApp-" + codename +
+                           " --name WebApp-" + codename +
                            " --profile " + firefox_profile_path +
                            " --no-remote ")
             if privatewindow:


### PR DESCRIPTION
Firefox webapps start with they're custom icon but 1/2sec after go back to the Firefox one. 

Adding the argument '--name foo' fix the problem.