### PR TITLE
Display navbar children to fix pop-ups on firefox

### DIFF
--- a/usr/share/webapp-manager/firefox/profile/chrome/userChrome.css
+++ b/usr/share/webapp-manager/firefox/profile/chrome/userChrome.css
@@ -1,3 +1,7 @@
 #nav-bar, #identity-box, #tabbrowser-tabs, #TabsToolbar {
-	visibility: collapse !important;
+	visibility: collapse;
+}
+
+#nav-bar * {
+    visibility: visible !important;
 }


### PR DESCRIPTION
I found that removing "!important" from the rule in userChrome.css did not cause the navbar to be displayed, so I modified the file a bit to display the navbar's children (and their children, recursively - otherwise it doesn't work). The result is that you can now install extensions without temporarily altering the userChrome.css file, and also permission pop-ups work instead of flickering endlessly.

closes #235 , closes #211 , closes #168 , closes #145 