### PR TITLE
Consistently include a space *before* parameters when building exec_string

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -286,12 +286,12 @@ class WebAppManager:
                            " --class WebApp-" + codename +
                            " --name WebApp-" + codename +
                            " --profile " + firefox_profile_path +
-                           " --no-remote ")
+                           " --no-remote")
             if privatewindow:
-                exec_string += "--private-window "
+                exec_string += " --private-window"
             if custom_parameters:
                 exec_string += " {}".format(custom_parameters)
-            exec_string += "\"" + url + "\"" + "'"
+            exec_string += " \"" + url + "\"" + "'"
             # Create a Firefox profile
             shutil.copytree('/usr/share/webapp-manager/firefox/profile', firefox_profile_path, dirs_exist_ok = True)
             if navbar:
@@ -304,10 +304,10 @@ class WebAppManager:
             exec_string = ("sh -c 'XAPP_FORCE_GTKWINDOW_ICON=\"" + icon + "\" " + browser.exec_path +
                            " --class WebApp-" + codename +
                            " --profile " + firefox_profile_path +
-                           " --no-remote ")
+                           " --no-remote")
             if privatewindow:
-                exec_string += "--private-window "
-            exec_string += "\"" + url + "\"" + "'"
+                exec_string += " --private-window"
+            exec_string += " \"" + url + "\"" + "'"
             # Create a Firefox profile
             shutil.copytree('/usr/share/webapp-manager/firefox/profile', firefox_profile_path, dirs_exist_ok = True)
             if navbar:
@@ -323,7 +323,7 @@ class WebAppManager:
             exec_string = browser.exec_path
             exec_string += " --application-mode "
             exec_string += " --profile=\"" + epiphany_orig_prof_dir + "\""
-            exec_string += " " + "\"" + url + "\""
+            exec_string += " \"" + url + "\""
             if custom_parameters:
                 exec_string += " {}".format(custom_parameters)
         else:


### PR DESCRIPTION
This closes #269, by fixing `custom_parameters` having two spaces before it and none after it for Firefox apps.

By include the separating space at the beginning of each new parameter string, instead of switching between the beginning and end, there is less chance of this error happening again.