### PR TITLE
Fix Gnome wayland handling window names

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -303,6 +303,7 @@ class WebAppManager:
             firefox_profile_path = os.path.join(firefox_profiles_dir, codename)
             exec_string = ("sh -c 'XAPP_FORCE_GTKWINDOW_ICON=\"" + icon + "\" " + browser.exec_path +
                            " --class WebApp-" + codename +
+                           " --name WebApp-" + codename +
                            " --profile " + firefox_profile_path +
                            " --no-remote ")
             if privatewindow:
@@ -333,11 +334,13 @@ class WebAppManager:
                 exec_string = (browser.exec_path +
                                " --app=" + "\"" + url + "\"" +
                                " --class=WebApp-" + codename +
+                               " --name=WebApp-" + codename +
                                " --user-data-dir=" + profile_path)
             else:
                 exec_string = (browser.exec_path +
                                " --app=" + "\"" + url + "\"" +
-                               " --class=WebApp-" + codename)
+                               " --class=WebApp-" + codename +
+                               " --name=WebApp-" + codename)
 
             if privatewindow:
                 if browser.name == "Microsoft Edge":


### PR DESCRIPTION
Fixes a problem in Gnome wayland with handling the window names.

Closes https://github.com/linuxmint/webapp-manager/issues/103