### PR TITLE
Firefox: hide navigation toolbars only when top menu is inactive

### DIFF
--- a/usr/share/webapp-manager/firefox/profile/chrome/userChrome.css
+++ b/usr/share/webapp-manager/firefox/profile/chrome/userChrome.css
@@ -1,6 +1,8 @@
-#toolbar-menubar[inactive="true"] ~ #TabsToolbar,
-#titlebar:has(#toolbar-menubar[inactive="true"]) ~ #nav-bar {
-	visibility: collapse;
+#navigator-toolbox:not(:hover, :focus, :active) {
+  #toolbar-menubar[inactive="true"] ~ #TabsToolbar,
+  #titlebar:has(#toolbar-menubar[inactive="true"]) ~ #nav-bar {
+	  visibility: collapse;
+  }
 }
 
 #nav-bar * {

--- a/usr/share/webapp-manager/firefox/profile/chrome/userChrome.css
+++ b/usr/share/webapp-manager/firefox/profile/chrome/userChrome.css
@@ -1,4 +1,5 @@
-#nav-bar, #identity-box, #tabbrowser-tabs, #TabsToolbar {
+#toolbar-menubar[inactive="true"] ~ #TabsToolbar,
+#titlebar:has(#toolbar-menubar[inactive="true"]) ~ #nav-bar {
 	visibility: collapse;
 }
 


### PR DESCRIPTION
Hiding navigation toolbars is nice most of the time, however sometimes you have several tabs open either on purpose or by accident, and want to close some of them. (e.g. #101, #105, #266)

But going back into the webapp-manager to edit the "hide navigation bar" option is inconvenient especially when you must do this every single time there are extraneous tabs.

In fact Firefox already has a nice feature that hides the menubar when it's not needed, and shows it only when it's needed - the Alt button.

This PR hooks the rest of the navigation bar onto this mechanism, so pressing Alt will now toggle the menubar+navbars together.

On my version of Firefox (latest) it's not necessary to explicitly style `#identity-box, #tabbrowser-tabs` since they are inside the other elements, I'm not sure of the purpose of the original code. But that's what this PR & code review is for, to discuss this. :)
