### PR TITLE
Remove call to favicongrabber.com

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -4,7 +4,6 @@
 import configparser
 import gettext
 from io import BytesIO
-import json
 import locale
 import os
 from random import choice
@@ -512,25 +511,7 @@ def download_favicon(url):
     (scheme, netloc, path, _, _, _) = urllib.parse.urlparse(url)
     root_url = "%s://%s" % (scheme, netloc)
 
-    # try favicon grabber first
-    try:
-        response = requests.get("https://favicongrabber.com/api/grab/%s?pretty=true" % netloc, timeout=3)
-        if response.status_code == 200:
-            source = response.content.decode("UTF-8")
-            array = json.loads(source)
-            for icon in array['icons']:
-                image = download_image(root_url, icon['src'])
-                if image is not None:
-                    t = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-                    images.append(["Favicon Grabber", image, t.name])
-                    image.save(t.name)
-            images = sorted(images, key = lambda x: x[1].height, reverse=True)
-            if images:
-                return images
-    except Exception as e:
-        print(e)
-
-    # Fallback: Check HTML and /favicon.ico
+    # Check HTML and /favicon.ico
     try:
         response = requests.get(url, timeout=3)
         if response.ok:


### PR DESCRIPTION
As mentioned in #312 the certificate of  [https://favicongrabber.com/](https://favicongrabber.com/) has expired. Additionally, the site has not been functioning properly since 2021 and is running outdated, vulnerable software. Since we have no control over this site, I removed the call to its API.

This change might be worth backporting to all currently supported versions of Linux Mint.