### PR TITLE
Prevent preview of unsaved images

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -536,8 +536,8 @@ def download_favicon(url):
                     image = download_image(root_url, link)
                     if image is not None:
                         t = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-                        images.append([iconformat, image, t.name])
                         image.save(t.name)
+                        images.append([iconformat, image, t.name])
 
     except Exception as e:
         print(e)


### PR DESCRIPTION
Currently, the downloaded images are added to the result list regardless of whether the save operation was successful. If the save failed, `webapp-manager` still attempts to display the preview, which results in a blank image, as shown below:
![Bildschirmfoto vom 2025-01-05 16-28-13](https://github.com/user-attachments/assets/4229a357-b88b-4221-922e-89df563322b2).

I modified the behavior to ensure that only successfully saved images are added to the result list. This will prevent the display of blank previews for failed saves.