### PR TITLE
Add support for Google's Favicon API as a fallback option

### DIFF
--- a/usr/lib/webapp-manager/common.py
+++ b/usr/lib/webapp-manager/common.py
@@ -510,6 +510,13 @@ def _find_property(soup, iconformat, url):
 def _find_url(_soup, iconformat, url):
     yield iconformat
 
+def _find_google_api_favicon(_soup, iconformat, url):
+    url = urllib.parse.quote(url, safe='')
+    #response = requests.get("https://www.google.com/s2/favicons?sz=32&domain=%s" % url, timeout=3)
+    #link = response.url
+    link = "https://www.google.com/s2/favicons?sz=32&domain=%s" % url
+    yield link
+
 
 def download_favicon(url):
     images = []
@@ -535,6 +542,7 @@ def download_favicon(url):
                 ("msapplication-square70x70logo", _find_meta_content),
                 ("og:image", _find_property),
                 ("favicon.ico", _find_url),
+                ("google-api", _find_google_api_favicon),
             ]
 
             # icons defined in the HTML


### PR DESCRIPTION
As described in my issue (https://github.com/linuxmint/webapp-manager/issues/349) there is a problem when trying to download Favicons for pages with redirects. Google hosts an API to reliably get the Favicon for any page by just passing in the URL.

I would suggest adding support for this API to use when fetching Favicons for a Webapp. Even though Google as a company is not quite Open-Source friendly, their API has no apparent underlying license and is used by many projects.

I believe the added reliability is worth the ideological compromise.

related to https://github.com/linuxmint/webapp-manager/issues/340 and my own https://github.com/linuxmint/webapp-manager/issues/349