### PR TITLE
Add suggested-action class to Add button

### DIFF
--- a/usr/lib/webapp-manager/webapp-manager.py
+++ b/usr/lib/webapp-manager/webapp-manager.py
@@ -84,6 +84,7 @@ class WebAppManagerWindow:
         self.headerbar = self.builder.get_object("headerbar")
         self.favicon_button = self.builder.get_object("favicon_button")
         self.add_button = self.builder.get_object("add_button")
+        self.add_button.get_style_context().add_class("suggested-action")
         self.remove_button = self.builder.get_object("remove_button")
         self.edit_button = self.builder.get_object("edit_button")
         self.run_button = self.builder.get_object("run_button")


### PR DESCRIPTION
Currently, there's no hint on how to get started when you first open the Web App Manager. As a result, it might not be entirely clear where a new user should click to create their first web app.

Adding the `suggested-action` class to the "+" button makes it stand out more. That way, new users could intuitively know where to click to get started.